### PR TITLE
ci: setup travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+  - oraclejdk8
+  - openjdk8


### PR DESCRIPTION
Travis CI is a continuous integration system that integrates with GitHub and offers free CI for [Open Source projects](https://travis-ci.com/plans)

Other Apereo projects, including [uPortal](https://travis-ci.org/Jasig/uPortal) and [OpenEquella](https://travis-ci.org/equella/Equella), have found it to be an effective testing platform.

Here is a sample of what the output would look like for the notification hub ui https://travis-ci.com/ChristianMurphy/notification-ui/builds/92946317
It is running `mvn test -B` on Oracle JDK 8 and Open JDK 8 on Linux.

If this is something that would be a good fit for the notification hub ui, the instructions to enable Travis CI for a repo can be found here: https://docs.travis-ci.com/user/tutorial