### PR TITLE
feat - issue/26 - allow short code in SMS service

### DIFF
--- a/src/main/java/uk/ac/ed/notify/service/TwillioOutboundSmsService.java
+++ b/src/main/java/uk/ac/ed/notify/service/TwillioOutboundSmsService.java
@@ -68,11 +68,16 @@ public class TwillioOutboundSmsService implements OutboundSmsService {
             throw new IllegalStateException(
                     "Could not evaluate a fromNumber for notification:  " + notification.getNotificationId());
         }
+        final String completeFromNumber = fromNumber.length() < 7
+                ? fromNumber                      // Short code
+                : US_DIALING_PREFIX + normalizePhoneNumber(fromNumber); // Standard U.S. phone number
+        logger.debug("Checked fromNumber for short code.  Using '{}' as 'from' phoneNumber for SMS service",
+                completeFromNumber);
 
         final String toNumber = US_DIALING_PREFIX + normalizePhoneNumber(deliveryAddress.getValue());
         final Message message = Message.creator(
                 new PhoneNumber(toNumber),
-                new PhoneNumber(US_DIALING_PREFIX + normalizePhoneNumber(fromNumber)),
+                new PhoneNumber(completeFromNumber),
                 notification.getBody()
         ).create();
 


### PR DESCRIPTION
Resolves #26 .

If a 'short code' is detected in the 'from' phone number for the SMS service, the US prefix will not be added.