### PR TITLE
Fix for #33: prevent notification creation when attempting to delete a non-existant notication via email

### DIFF
--- a/src/main/java/uk/ac/ed/notify/service/EmailNotificationHandlingService.java
+++ b/src/main/java/uk/ac/ed/notify/service/EmailNotificationHandlingService.java
@@ -91,8 +91,10 @@ public class EmailNotificationHandlingService {
                 Notification existingNotification = notificationRepository.findByPublisherIdAndPublisherNotificationId(notification.getPublisherId(), notification.getPublisherNotificationId());
                 if (existingNotification == null) {
                     logger.info("notification not exist in db, ignore");
-                    notification.setNotificationId(null);
-                    handleNotification(AuditActions.CREATE_NOTIFICATION, notification);
+                    /*
+                     * Issue 33
+                     * Do not create a notification if an attempt is made to delete a non-existant one
+                     */
                 } else {
                         notification.setNotificationId(existingNotification.getNotificationId());
                         logger.info("existing notification found, delete");

--- a/src/main/java/uk/ac/ed/notify/service/EmailNotificationHandlingService.java
+++ b/src/main/java/uk/ac/ed/notify/service/EmailNotificationHandlingService.java
@@ -90,7 +90,7 @@ public class EmailNotificationHandlingService {
                 logger.info("action: delete");
                 Notification existingNotification = notificationRepository.findByPublisherIdAndPublisherNotificationId(notification.getPublisherId(), notification.getPublisherNotificationId());
                 if (existingNotification == null) {
-                    logger.info("notification not exist in db, ignore");
+                    logger.warn("notification not exist in db, ignore");
                     /*
                      * Issue 33
                      * Do not create a notification if an attempt is made to delete a non-existant one


### PR DESCRIPTION
Remove the 2 lines of code in the email notification handler service
which create a notification when a notification delete is requested on
a notification that does not exist.
Leave the logging in place.